### PR TITLE
add documentation. It's a start, but some parts aren't quite finished

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,0 +1,20 @@
+Factor was originally designed by Slava Pestov in 2002, as a scripting language implemented on the JVM for game engines. The platform and ecosystem has come a long way since that time, as has the core of the language itself. Factor's standard library has grown enormous, and its implementation, including its self-hosting native code optimising compiler, is now written almost entirely in Factor.
+
+Factor can create standalone, and even GUI applications that behave exactly the same on Linux, Windows and Mac OS.
+
+Factor is a simple, yet powerful and expressive stack-oriented high-level language in the vein of Forth, Joy and Lisp. It proposes a concatenative (point-free and compositional) model of data flow, alongside extreme extensibility and a [CLOS](http://enwp.org/Common_Lisp_Object_System)-derived object system.
+
+Homoiconicity is a large part of Factor's programming model. All values, including functions and blocks of Factor code, go on the same stack and can be manipulated in the same way. This is a simple, yet powerful paradigm that invites interesting solutions to problems, and indefinite extensibility.
+
+Factor requires from the reader a mindset apart from C or Python. Because of its compositional programming model, each function's output is used as input to the next one. Functions can use other functions or blocks of literal Factor code as input. In this way, it's rather like a (one-directional) Unix pipeline, but far more advanced while being less complicated. It takes some getting used to, but interactive development and re-**Factor**ing are encouraged, and becomes quite fun and interesting to use.
+
+The Factor programming language is open source, and you can find it in active development on [GitHub](https://github.com/factor/factor).
+
+If you're even a little bit new to Factor, it's highly recommended you read the [Factor cookbook](http://docs.factorcode.org/content/article-cookbook.html) and [Your first program](http://docs.factorcode.org/content/article-first-program.html) sections of the Factor documentation before continuing.
+
+#### Glossary of Factor terms
+
+* **Word** Essentially a function, which takes its arguments from, and returns values to, the **stack**. All words must have a declared stack effect. All elements of Factor's syntax are **words**, which makes defining new syntax very easy.
+* **Vocabulary** A collection of **words** organised in a directory or source-file, like a module or library in other languages.
+* **Stack** A last-in-first-out list of references to dynamically-typed values used for all operations; the primary way of passing data between functions. It is an implementation detail; Factor could be mostly implemented using term rewriting.
+* **Program** A series of **words** that manipulate the **stack** at runtime. This gives the language a powerful foundation which allows many abstractions and paradigms to be built on top.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,136 @@
+# Installing Factor, and making Exercism and Factor play nice
+
+[**Even if you already have Factor installed, you still need to read the last section of this document for important information about Factor's relationship with Exercism.**](#making-factor-and-exercism-play-nice)
+
+---
+
+## Installing Factor
+
+To install Factor, you have a couple of choices.
+
+For production servers and mission-critical applications, we recommend a stable binary release from the homepage, but because all commits and pulls are thoroughly tested and carefully reviewed, the [nightly builds](#nightly) and even the [bleeding edge of `git`](#autobuild-from-source) are quite safe.
+
+---
+
+### Stable
+
+Download a binary for your platform from <http://factorcode.org>, and run the installer.
+
+These binaries and sources are typically a few months behind `git`. If you want the latest bugfixes and features (dark mode UI, perhaps?), or if your platform isn't listed on that page (i.e. not Windows, Linux or Mac), then see the ["build from source"](#autobuild-from-source) section below, to obtain the up-to-the-minute version.
+
+---
+### Nightly
+
+The website also provides nightly binaries, built from git. Only builds that pass are shown.
+
+---
+
+### (Auto)build from source
+
+If neither of the above options are good enough for you, and you need all the latest tech, then you will need a modern C++ compiler like GCC >=4.8 or Clang >=3.5, `make`, `curl`, and:
+
+1. Download the `build` shell script: [**here** for `sh`, `bash`, etc](https://raw.githubusercontent.com/factor/factor/master/build.sh) or [**here** for Windows](https://raw.githubusercontent.com/factor/factor/master/build.cmd). Put it in the directory where Factor should be installed.
+2. Run it with the `install` argument: `./build.sh install`, or `.\build.cmd install` on Windows. This will clone Factor's `git` repository, build it, and download a Factor VM image from <http://factorcode.org>. This process will take between 2 and 20 minutes, depending on the speed of your internet connection and processor.
+3. You can now run the generated `factor` or `factor.exe` binary. Try `factor --help` for help. You can also access documentation from the command line, or by pressing <kbd>F1</kbd> in the GUI Listener, which will open the docs browser.
+4. In the future, just `cd` into Factor's cloned repository and type `./build.sh update` or `.\build.cmd update`, respectively, to pull from git and rebuild in-place, and download a new VM image if the checksums differ.
+
+Your tree, from the working directory of the original build script, might look something like this:
+
+```
+.
+├── build.sh
+└── factor
+    ├── basis
+    ├── boot.unix-x86.64.image
+    ├── boot.unix-x86.64.image.bak
+    ├── build.cmd
+    ├── build.sh
+    ├── checksums.txt
+    ├── core
+    ├── extra
+    ├── factor
+    ├── Factor.app
+    ├── factor.bak
+    ├── factor.image
+    ├── factor.image.bak
+    ├── factor.image.fresh
+    ├── GNUmakefile
+    ├── key-log.txt
+    ├── libfactor.a
+    ├── libfactor-ffi-test.so
+    ├── LICENSE.txt
+    ├── logs
+    ├── misc
+    ├── Nmakefile
+    ├── README.md
+    ├── unmaintained
+    ├── vm
+    └── work
+```
+
+You no longer need the top level buildscript.
+
+---
+
+### (Actually) Build from source
+
+Not recommended as things can go wrong too easily, but this may be your only option. In most cases, a simple `make` should suffice.
+
+---
+
+## Making Exercism and Factor play nice
+
+Before you go any further, we need to talk about Factor's directory structure.
+
+When you bootstrap a new vocabulary from the Factor listener:
+```
+( scratchpad ) USE: tools.scaffold
+Loading resource:basis/tools/scaffold/scaffold.factor
+Loading resource:basis/tools/scaffold/scaffold-docs.factor
+( scratchpad ) "new-vocab" scaffold-work
+```
+you are creating a new directory in `place-factor-is-installed/work/new-vocab`, containing the file `new-vocab.factor`. `core`, `basis`, `extra`, `misc`, and `unmaintained` are all default vocabulary root paths in `place-factor-is-installed`, and most of them need to exist for Factor to run. `work` just happens to hold *your* personal vocabulary projects. Factor does not, by default, look for vocabularies to load outside of these roots.
+
+On the other hand, Exercism's directory for exercises is in a directory in your home folder. `C:\Users\You\exercism\` on Windows, or `~/exercism` on Unicies. See the problem?
+
+There is a disparity between where Factor wants your code and where Exercism wants your code. Happily, however, there are a few solutions.
+
+The cleanest, preferred solution, if your platform / filesystem is capable of [hard links](http://enwp.org/Hard_link), is:
+
+1. Run in the listener: `USE: tools.scaffold "exercism" scaffold-work`
+2. a [hard link](http://enwp.org/Hard_link) between `~/exercism/factor` and the new `place-factor-is-installed/work/exercism`. GNU Coreutils `ln` creates hard links by default, so `ln ~/exercism/factor place-factor-is-installed/work/exercism` should do the job.
+3. Now, Exercism problems folders will be used as Factor sub-vocabularies of the `exercism` vocabulary.
+
+**Remember, deleting something on one end of the hard link will delete the object on the other end!** Symbolic links are one-way, but hard links are not, so be careful.
+
+An example:
+
+```
+your-home-directory
+│
+├── exercism
+│   └── factor           <-------------------+
+│       └── hello-world                      |
+│           ├── hello-world.factor           |
+│           └── hello-world-tests.factor     |
+└── factor                                   |
+    ├── basis                                |- hard linked!
+    ├── core                                 |
+    ├── extra                                |
+    ├── misc                                 |
+    └── work                                 |
+        └── exercism     <-------------------+
+            └── hello-world
+                ├── hello-world.factor
+                └── hello-world-tests.factor
+```
+
+If you're not blessed with hard links, then you can use one of the three other methods mentioned in the [Factor documentation on this](http://docs.factorcode.org/content/article-add-vocab-roots.html).
+
+1. Use an environment variable. Factor looks at the `FACTOR_ROOTS` environment variable for a list of paths, separated by `:` on Unicies, `;` on Windows, or whatever your path separator is. This means:
+  * `export FACTOR_ROOTS="home/you/exercism/factor:another/directory"` in your `.bashrc` or equivalent
+  * On Windows, changing your user's enivronment variables to set `FACTOR_ROOTS` to `C:\Users\You\exercism\factor;C:\Another\Directory`.
+
+2. Create a configuration file. You can list additional vocabulary roots in a file read by Factor at startup: [Additional vocabulary roots file](http://docs.factorcode.org/content/article-.factor-roots.html)
+
+3. Call the [add-vocab-root](http://docs.factorcode.org/content/word-add-vocab-root%2Cvocabs.loader.html) word from your [.factor-rc file](http://docs.factorcode.org/content/article-.factor-rc.html).

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,0 +1,31 @@
+## Ways to learn Factor
+
+There are many great resources for learning Factor.
+
+* Documentation is an important part of every good Factor vocabulary. Consequently, Factor's amazing and extensive docs are available offline, searchable right from the GUI Listener, or on the command line. These same docs, equally searchable, can be found online. <br /> <http://docs.factorcode.org>
+
+* Factor's GitHub repository hosts a Wiki. <br /> <http://github.com/factor/factor/wiki>
+
+* Björn Lindqvist, one of Factor's developers, has a repo full of interesting tips and tricks. It's not updated very often and is WIP (and much of its content is being moved to the GitHub Wiki), but it's still very cool stuff. <br /> <http://github.com/bjourne/playground-factor>
+
+* [Learn X in Y Minutes](http://learnxinyminutes.com) is a good resource for many languages, and Factor is no exception. Its tutorial is not *extensive* by any means, but it is a good reference and enough to get you started. <br /> <http://learnxinyminutes.com/docs/factor>
+
+* [Rosetta Code](http://rosettacode.org/wiki/Rosetta_Code) is a [programming chrestomathy ](https://en.wikipedia.org/wiki/Chrestomathy) site. On it, among the hundreds of other languages, is [Rosetta Code:Factor](https://rosettacode.org/wiki/Category:Factor), where you can find solutions to many problems, and compare with languages you know. It also serves as a good reference and starting point for solutions. <br /> <http://rosettacode.org/wiki/Category:Factor>
+
+Lastly and maybe leastly,
+
+* The [Concatenative Wiki](concatenative.org/wiki/view/Factor). Note that while it has good content and it's not wrong by any means, it's not really updated and [is being phased out](https://github.com/factor/factor/issues/706) in favour of the GitHub Wiki above.
+
+* [Stack Overflow](http://stackoverflow.com/questions/tagged/factor-lang). There's not a large community (okay, about three users including yours truly) but ask there if you're really, truly stuck and someone will surely help you out.
+
+* The [Mailing List](http://concatenative.org/wiki/view/Factor/Mailing%20list). Here, you can ask about anything Factor-related and a collaborator will answer helpfully.
+
+* [Factor is on IRC](http://concatenative.org/wiki/view/Concatenative%20IRC%20channel)! Come join us; we're happy to help.
+
+* Learn and read about [Joy](http://enwp.org/Joy_%28programming_language%29), [Forth](http://enwp.org/Forth_%28programming_language%29) and concatenative / stack-based programming in general.
+
+* Learn and read about the [Common Lisp Object System](http://enwp.org/Common_Lisp_Object_System). The CLOS is widely regarded as the most advanced and innovative object model in the world, and Factor's object model is heavily based on and inspired by it.
+
+* In a lot of ways, Factor is a Lisp. It's a postfix, point-free, functional, inside-out-and-backwards funny-looking one, but many ideologies are the same. Because of this, it may be beneficial to learn a Lisp, preferably a Lisp-1 in which functions and variables share a namespace (because functions are values in functional programming). Yours truly humbly recommends [Scheme](http://schemers.org), or, for something more modern and usable, [Racket](http://racket-lang.org), a descendant of Scheme.
+
+Finally, Factor is written almost entirely in Factor. So, read the source code, and search the docs for words you don't know.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,0 +1,14 @@
+## Recommended learning resources
+
+* The [Official Factor Documentation](http://docs.factorcode.org).
+* The [Factor GitHub Repository Wiki](http://github.com/factor/factor/wiki).
+* [Björn Lindqvist's Factor Playground](http://github.com/bjourne/playground-factor).
+* [Learn X in Y Minutes, where X = Factor](http://learnxinyminutes.com/docs/factor).
+* [Factor on RosettaCode](http://rosettacode.org/wiki/Category:Factor).
+* The [Concatenative.org Factor Wiki](concatenative.org/wiki/view/Factor).
+* The [`factor-lang` tag on Stack Overflow](http://stackoverflow.com/questions/tagged/factor-lang).
+* The [Factor Mailing List](http://concatenative.org/wiki/view/Factor/Mailing%20list).
+* The [Factor IRC Channel](http://concatenative.org/wiki/view/Concatenative%20IRC%20channel).
+* The [Joy](http://enwp.org/Joy_%28programming_language%29) and [Forth](http://enwp.org/Forth_%28programming_language%29) programming languages.
+* The [Common Lisp Object System](http://enwp.org/Common_Lisp_Object_System).
+* [Factor itself](http://github.com/factor/factor).

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,0 +1,15 @@
+# The `test.tools` framework
+
+Factor has a very simple, yet very powerful (like Factor itself) test framework in its standard library.
+
+```
+{ 1 } [ 1 ]             unit-test
+{   } [ "Hello" print ] unit-test ! print doesn't leave anything on the stack
+{ 3 } [ 1 2 + ]         unit-test
+```
+
+Now, assuming you've learned a little Factor by now, you will see that the `unit-test` word (which is actually a special syntax element) takes an array of how the stack should look after running the given quotation.
+
+Words should be concise and simplified. They should not be more than 5 or 10 lines long in most cases, and their inputs and outputs should be simple and clearly understandable, and, importantly, do one thing and do it well. Consequently, a given word should be easily `unit-test`able.
+
+Unit tests (a bunch of assertions like above) go in a file called `vocab-name-tests.factor` which is already created for you by Exercism, but would need to be created by hand or `"vocab-name" scaffold-tests`. Run a vocabulary's tests with `"vocab-name" test`.


### PR DESCRIPTION
this lets us cross off almost all of the documentation bullets in [#1](https://github.com/exercism/xfactor/issues/1), except for the `TESTS.md`, which is on its way.