### PR TITLE
Direct people installing Factor to the correct page

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,6 +1,6 @@
 ## Testing Exercises
 
-If you followed the [installation instructions](http://exercism.io/languages/factor#installing), just run the provided test suite against your implementation with `"exercise-name" test`.
+If you followed the [installation instructions](http://exercism.io/languages/factor/installing), just run the provided test suite against your implementation with `"exercise-name" test`.
 
 ## Submitting Exercises
 


### PR DESCRIPTION
This fixes a broken link I found in the `README` of a downloaded Factor exercise.

Thank you for building and maintaining this awesome project!