### PR TITLE
update / cleanup installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,6 @@ Here's what you need to do to start working with the Factor code in the `exercis
 
 If you think you've found a factual or technical error, or you just have a question or suggestion about some part of the Markdown or Factor documentation, we'd :heart: you to open an issue or pull request.
 
-## License
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Katrina Owen, _@kytrinyx.com
-
 ### [Factor icon](https://github.com/exercism/xfactor/tree/master/img/icon.png)
 
 The Factor "Tyrannosaurus Rex" logo is owned by John Benediktsson. We have adapted it, changing the colour scheme, with his permission.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,27 +1,19 @@
 # Installing Factor, and making Factor and Exercism play nice
 
-[**Even if you already have Factor installed, you still need to read the last section of this document for important information about testing Factor code in the Exercism environment.**](#play-nice)
+[**Even if you already have Factor 0.98 installed, you still need to read the last section of this document for important information about testing Factor code in the Exercism environment.**](#play-nice)
 
 ---
 
 ## Installing Factor
 
-To install Factor, you have a couple of choices.
+To install Factor, you should use a [nightly](#nightly) or [bleeding-edge](#autobuild-from-source) build.
 
-For production servers and mission-critical applications, we recommend a stable binary release from the homepage, but because all commits and pulls are thoroughly tested and carefully reviewed, the [nightly builds](#nightly) and even the [bleeding edge of `git`](#autobuild-from-source) are quite safe.
-
----
-
-### Stable
-
-Download a binary for your platform from <http://factorcode.org>, and run the installer.
-
-These binaries and sources are typically a few months behind `git`. If you want the latest bugfixes and features (dark mode UI, perhaps?), or if your platform isn't listed on that page (i.e. not Windows, Linux or Mac), then see the ["build from source"](#autobuild-from-source) section below, to obtain the up-to-the-minute version.
+***The last stable release of Factor was [0.97 released 2 Nov 2014](https://re-factor.blogspot.com/2014/11/factor-097-now-available.html) -- this is quite out of date and not recommended.***
 
 ---
 ### Nightly
 
-The website also provides nightly binaries, built from git. Only builds that pass are shown.
+<http://factorcode.org> also provides nightly binaries, built from git. Only builds that pass are shown.
 
 ---
 
@@ -29,12 +21,15 @@ The website also provides nightly binaries, built from git. Only builds that pas
 
 If neither of the above options are good enough for you, and you need all the latest tech, then you will need a modern C++ compiler like GCC >=4.8 or Clang >=3.5, `make`, `curl`, and:
 
-1. Download the `build` shell script: [**here** for `sh`, `bash`, etc](https://raw.githubusercontent.com/factor/factor/master/build.sh) or [**here** for Windows](https://raw.githubusercontent.com/factor/factor/master/build.cmd). Put it in the directory where Factor should be installed.
-2. Run it with the `install` argument: `./build.sh install`, or `.\build.cmd install` on Windows. This will clone Factor's `git` repository, build it, and download a Factor VM image from <http://factorcode.org>. This process will take between 2 and 20 minutes, depending on the speed of your internet connection and processor.
-3. You can now run the generated `factor` or `factor.exe` binary. Try `factor --help` for help. You can also access documentation from the command line, or by pressing <kbd>F1</kbd> in the GUI Listener, which will open the docs browser.
-4. In the future, just `cd` into Factor's cloned repository and type `./build.sh update` or `.\build.cmd update`, respectively, to pull from git and rebuild in-place, and download a new VM image if the checksums differ.
+1. Download the `build` shell script: [**here** for Unix-likes / POSIX shells](https://raw.githubusercontent.com/factor/factor/master/build.sh) or [**here** for Windows](https://raw.githubusercontent.com/factor/factor/master/build.cmd). Put it in the directory where Factor should be installed.
 
-Your tree, from the working directory of the original build script, might look something like this:
+2. Run it like `./build.sh install`, or `.\build.cmd install` on Windows. <sub>This will clone Factor's `git` repository, build it, and download a Factor VM image from <http://factorcode.org>. This process will take between 2 and 20 minutes, depending on the speed of your internet connection and processor.</sub>
+
+3. You can now run the generated `factor` or `factor.exe` binary. Try `factor --help` for help. You can also access documentation from the command line, or by pressing <kbd>F1</kbd> in the GUI Listener, which will open the docs browser.
+
+4. In the future, just `cd` into Factor's installation and type `./build.sh update`, or `.\build.cmd update` on Windows, to pull from git and rebuild in-place, and download a new VM image if one exists.
+
+The file structure may now look like this:
 
 ```
 .
@@ -42,24 +37,17 @@ Your tree, from the working directory of the original build script, might look s
 └── factor
     ├── basis
     ├── boot.unix-x86.64.image
-    ├── boot.unix-x86.64.image.bak
     ├── build.cmd
     ├── build.sh
-    ├── checksums.txt
     ├── core
     ├── extra
     ├── factor
     ├── Factor.app
-    ├── factor.bak
     ├── factor.image
-    ├── factor.image.bak
-    ├── factor.image.fresh
     ├── GNUmakefile
-    ├── key-log.txt
     ├── libfactor.a
     ├── libfactor-ffi-test.so
     ├── LICENSE.txt
-    ├── logs
     ├── misc
     ├── Nmakefile
     ├── README.md
@@ -68,13 +56,13 @@ Your tree, from the working directory of the original build script, might look s
     └── work
 ```
 
-You no longer need the top level buildscript.
+You no longer need the top level `build.sh`.
 
 ---
 
-### (Actually) Build from source
+### Manually build from source
 
-Not recommended as the buildscripts are quite good at touchlessly setting things up, but this may be your only option. In most cases, a simple `make` should suffice.
+Clone the [repository](https://github.com/factor/factor) and use `make` in that folder.
 
 If `make` fails with an error about a non-present target, try `make factor` or, if you can read a Makefile, find the make target for your platform in `GNUmakefile`.
 
@@ -82,12 +70,21 @@ If *that* fails, open an issue on [factor/factor](https://github.com/factor/fact
 
 ---
 
+#### Stable (not recommended)
+
+**Note that [the automated test framework](languages/factor/tests) for Factor exercises on Exercism requires at least a [nightly build](#nightly)**.
+
+If you *don't* want automated testing or thousands of new features and bugfixes, download a Stable release binary for your platform from <http://factorcode.org>, and run the installer.
+
+---
+
 ## Making Exercism and Factor work together <a name="play-nice"> </a>
 
-Name clashes between Exercism and the Factor standard library, Exercism and Factor's mutual strictness about filenames, and Factor's reluctance to find vocabularies outside its source tree are all **factor**s making it kind of tricky for Exercism users to test their Factor code.
 
-A [wrapper vocabulary](https://github.com/catb0t/exercism.factor) has been written to streamline the Factor workflow in an Exercism context. This vocab allows users like you, and xfactor contributors alike, to use the `tools.test` framework to write tests in a familiar way, but automating and eliminating the manual configuration which was otherwise necessary.
+Due to limitations like name clashes and filename disagreements, it's rather difficult to use `tools.test` on Exercism exercises out of the box.
 
-To test your Factor code in your `exercism/factor` folder, just download [exercism.factor](https://github.com/catb0t/exercism.factor/archive/master.zip) and unzip it somewhere Factor can find it. `resource:work/exercism` is a good choice, so `testing.factor` is `resource:work/exercism/testing/testing.factor`.
+Instead, there is a [wrapper vocabulary](https://github.com/catb0t/exercism.factor) for the Factor workflow in an Exercism context. Users and Exercism maintainers alike can write tests in a familiar way, with much less overhead.
+
+To test your Factor solutions in your `exercism/factor` folder, follow the directions in [the README](https://github.com/catb0t/exercism.factor#getting-started).
 
 For information on using `exercism.testing`, refer to the [testing documentation](exercism.io/languages/factor#test), or to `exercism.testing`'s documentation by running `"exercism.testing" help` in Factor.


### PR DESCRIPTION
- cleaned up the installing documentation and
	noted that stable 0.97 cannot be used
	with exercism.testing

- removed the License section from README.md
	due to a directive about not including
	the license per-track