### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,14 +4,13 @@
   "repository": "https://github.com/exercism/xfactor",
   "active": false,
   "test_pattern": "TODO",
-
   "exercises": [
     {
       "slug": "hello-world",
       "difficulty": 1,
       "topics": [
-          "word definition",
-          "stack effect"
+        "word definition",
+        "stack effect"
       ]
     },
     {
@@ -28,24 +27,17 @@
       "slug": "two-fer",
       "difficulty": 2,
       "topics": [
-          "word definition",
-          "stack effect",
-          "text formatting",
-          "quotations"
+        "word definition",
+        "stack effect",
+        "text formatting",
+        "quotations"
       ]
     }
   ],
-
   "deprecated": [
-  ],
 
-  "ignored": [
-    "bin",
-    "docs"
   ],
-
   "foregone": [
 
   ]
-
 }


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.